### PR TITLE
Add norelativenumber to vim options

### DIFF
--- a/cppman/lib/cppman.vim
+++ b/cppman/lib/cppman.vim
@@ -34,6 +34,7 @@
 " For version 6.x: Quit when a syntax file was already loaded
 
 set nonu
+set norelativenumber
 set iskeyword+=:,=,~,[,],>,*
 set keywordprg=cppman
 map q :q!<CR>


### PR DESCRIPTION
This makes the (formatting breaking) number line in vim go away for those using relative numbers (a feature introduced somewhere around 7.3).
