### PR TITLE
Add clarification about Python 3 in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,8 @@ Installation
 
     $ pip install cppman
 
+Note that cppman requires Python 3. Make sure that either ``pip`` is configured for Python 3 installation, your default Python interpeter is version 3 or just use ``pip3`` instead.
+
 2. Arch Linux users can find it on AUR or using `Yaourt <https://wiki.archlinux.org/index.php/Yaourt>`_:
 
 .. code-block:: bash


### PR DESCRIPTION
Hey, when trying to use cppman for the first time I got this error:

```
"/usr/local/lib/python2.7/dist-packages/cppman/main.py", line 35, in <module>import urllib.request
ImportError: No module named request
```

It turns out that `urillib.request` is available for Python 3.x only. It took me a couple of minutes to fix it by uninstalling cppman in re-installing using `pip3`.

I hope that my small enhancement will help feature users to avoid this issue altogether. 