### PR TITLE
fix `TypeError: can't use a string pattern on a bytes-like object`

### DIFF
--- a/cppman/crawler.py
+++ b/cppman/crawler.py
@@ -38,7 +38,7 @@ class Document(object):
         self.url = url
         self.query = '' if '?' not in url else url.split('?')[-1]
         self.status = res.status
-        self.text = res.read()
+        self.text = res.read().decode()
         self.headers = dict(res.getheaders())
 
 


### PR DESCRIPTION
when i went to update the cppman cache i got this `TypeError: can't use a string pattern on a bytes-like object` when it was trying to regexsearch the response data.

anyway as far as I can tell, this tiny change seems to fix it.

duno if this happens for anyone else though.