### PR TITLE
fix "too many values to unpack" with --cache-all

### DIFF
--- a/cppman/main.py
+++ b/cppman/main.py
@@ -180,7 +180,7 @@ class Cppman(Crawler):
         print('Caching manpages from %s ...' % source)
         data = cursor.execute('SELECT * FROM "%s"' % source).fetchall()
 
-        for name, url in data:
+        for name, url, _ in data:
             print('Caching %s ...' % name)
             retries = 3
             while retries > 0:


### PR DESCRIPTION
It seems like cplusplus.com changed API a little bit. Now data comes with tag as the third argument in tuple:
```
('std::fstream::swap (fstream)', 'http://www.cplusplus.com/reference/fstream/fstream/swap/', 'C++11')
```

Tag can be empty string. But `--cache-all` is broken now:
```
λ cppman --cache-all
By default, cppman fetches pages on-the-fly if corresponding page is not found in the cache. The "cache-all" option is only useful if you want to view man pages offline. Caching all contents will take several minutes, do you want to continue [y/N]? y
Caching manpages from cplusplus.com ...
error: too many values to unpack (expected 2)

```

This commit just fixes `--cache-all` ignoring third argument