### PR TITLE
Cache warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Package Maintainers
 FAQ
 ---
 * Q: Can I use the system ``man`` command instead of ``cppman``?
-* A: Yes, just execute ``cppman -m true`` and all cached man pages are exposed to the system ``man`` command.  Note: You may want to download all available man pages with ``cppman -c``.
+* A: Yes, just execute ``cppman -m true`` and all cached man pages are exposed to the system ``man`` command.  Note: You may want to download all available man pages with ``sudo cppman -c``.
 
 Bugs
 ----

--- a/cppman/main.py
+++ b/cppman/main.py
@@ -186,8 +186,9 @@ class Cppman(Crawler):
             while retries > 0:
                 try:
                     self.cache_man_page(source, url, name)
-                except Exception:
-                    print('Retrying ...')
+                except Exception as exc:
+                    print('Encountered exception: ' + str(exc));
+                    print('\tRetrying ...')
                     retries -= 1
                 else:
                     self.success_count += 1

--- a/cppman/main.py
+++ b/cppman/main.py
@@ -187,7 +187,7 @@ class Cppman(Crawler):
                 try:
                     self.cache_man_page(source, url, name)
                 except Exception as exc:
-                    print('Encountered exception: ' + str(exc));
+                    print('Encountered exception: ' + str(exc))
                     print('\tRetrying ...')
                     retries -= 1
                 else:


### PR DESCRIPTION
I was following the README instructions on caching the commands for offline lookup. I got ambigious error/retry messages but not explaining what I did wrong. Turns out I didn't have root permissions.

Updating the README and printing an error message would save people some time in case they make the same mistake.