### PR TITLE
moving PATHS and make them dependent on XDG_* env variables

### DIFF
--- a/bin/cppman
+++ b/bin/cppman
@@ -124,8 +124,7 @@ def main():
                             options.source)
         else:
             config.Source = options.source
-            if config.UpdateManPath:
-                update_man3_link()
+            update_man3_link()
             print("Source set to `%s'." % options.source)
             sys.exit(0)
 
@@ -143,9 +142,8 @@ def main():
             raise Exception("invalid value `%s' for option `--use-mandb'" %
                             options.mandb)
         config.UpdateManPath = config.parse_bool(options.mandb)
-        if config.UpdateManPath:
-            update_mandb_path()
-            update_man3_link()
+        update_mandb_path()
+        update_man3_link()
         sys.exit(0)
 
     if options.rebuild_index:

--- a/cppman/environ.py
+++ b/cppman/environ.py
@@ -27,20 +27,27 @@ import os
 from cppman import get_lib_path
 from cppman.config import Config
 
-HOME = os.path.expanduser('~')
+HOME = os.environ["HOME"];
 
-man_dir = HOME + '/.local/share/man/'
-config_dir = HOME + '/.config/cppman/'
-config_file = config_dir + 'cppman.cfg'
+XDG_CACHE_HOME  = os.getenv("XDG_CACHE_HOME", os.path.join(HOME, ".cache"))
+XDG_CONFIG_HOME = os.getenv("XDG_CONFIG_HOME", os.path.join(HOME, ".config"))
+
+cache_dir   = os.path.join(XDG_CACHE_HOME, 'cppman')
+manindex_dir = os.path.join(cache_dir, 'manindex')
+config_dir  = os.path.join(XDG_CONFIG_HOME, 'cppman')
+config_file = os.path.join(config_dir, 'cppman.cfg')
 
 config = Config(config_file)
 
 try:
+    os.makedirs(cache_dir)
+    os.makedirs(manindex_dir)
     os.makedirs(config_dir)
+    update_man3_link()
 except:
     pass
 
-index_db_re = os.path.normpath(os.path.join(config_dir, 'index.db'))
+index_db_re = os.path.join(cache_dir, 'index.db')
 
 index_db = index_db_re if os.path.exists(index_db_re) \
     else get_lib_path('index.db')

--- a/cppman/main.py
+++ b/cppman/main.py
@@ -163,7 +163,7 @@ class Cppman(Crawler):
             raise KeyboardInterrupt
 
         try:
-            os.makedirs(environ.man_dir)
+            os.makedirs(environ.cache_dir)
         except:
             pass
 
@@ -210,7 +210,7 @@ class Cppman(Crawler):
             return
 
         try:
-            os.makedirs(os.path.join(environ.man_dir, source))
+            os.makedirs(os.path.join(environ.cache_dir, source))
         except OSError:
             pass
 
@@ -225,13 +225,13 @@ class Cppman(Crawler):
             f.write(groff_text.encode('utf-8'))
 
     def clear_cache(self):
-        """Clear all cache in man3"""
-        shutil.rmtree(environ.man_dir)
+        """Clear all cache in man"""
+        shutil.rmtree(environ.cache_dir)
 
     def man(self, pattern):
         """Call viewer.sh to view man page"""
         try:
-            avail = os.listdir(os.path.join(environ.man_dir, environ.source))
+            avail = os.listdir(os.path.join(environ.cache_dir, environ.source))
         except OSError:
             avail = []
 
@@ -319,4 +319,4 @@ class Cppman(Crawler):
 
     def get_page_path(self, source, name):
         name = self.get_normalized_page_name(name)
-        return os.path.join(environ.man_dir, source, name + '.3.gz')
+        return os.path.join(environ.cache_dir, source, name + '.3.gz')

--- a/cppman/util.py
+++ b/cppman/util.py
@@ -35,33 +35,33 @@ import bs4
 
 
 def update_mandb_path():
-    """Add ~/.local/share/man to $HOME/.manpath"""
-    HOME = os.path.expanduser('~')
-    manpath_file = os.path.normpath(os.path.join(HOME, '.manpath'))
-    manpath = '.local/share/man'
+    """Add $XDG_CACHE_HOME/cppman/man to $HOME/.manpath"""
+    manpath_file = os.path.join(environ.HOME, ".manpath")
+    man_dir      = environ.cache_dir
+    manindex_dir = environ.manindex_dirl
+
     lines = []
+
+    """ read all lines """
     try:
         with open(manpath_file, 'r') as f:
             lines = f.readlines()
     except IOError:
-        if not environ.config.UpdateManPath:
-            return
+        return
 
-    has_path = any([manpath in l for l in lines])
+    """ remove MANDATORY_MANPATH and MANDB_MAP entry """
+    lines = [line for line in lines if man_dir not in line]
 
     with open(manpath_file, 'w') as f:
         if environ.config.UpdateManPath:
-            if not has_path:
-                lines.append('MANDATORY_MANPATH\t%s\n' %
-                             os.path.normpath(os.path.join(HOME, manpath)))
-        else:
-            lines = [line for line in lines if manpath not in line]
+            lines.append('MANDATORY_MANPATH\t%s\n' % man_dir)
+            lines.append('MANDB_MAP\t\t\t%s\t%s\n' % (man_dir, manindex_dir))
 
         f.writelines(lines)
 
 
 def update_man3_link():
-    man3_path = os.path.join(environ.man_dir, 'man3')
+    man3_path = os.path.join(environ.cache_dir, 'man3')
 
     if os.path.lexists(man3_path):
         if os.path.islink(man3_path):
@@ -73,7 +73,7 @@ def update_man3_link():
             raise RuntimeError("Can't create link since `%s' already exists" %
                                man3_path)
     try:
-        os.makedirs(os.path.join(environ.man_dir, environ.config.Source))
+        os.makedirs(os.path.join(environ.cache_dir, environ.config.Source))
     except Exception:
         pass
 

--- a/misc/cppman.1
+++ b/misc/cppman.1
@@ -15,7 +15,7 @@ cppman uses Vi Improved as a pager.
 Press 'q' to leave pager.
 Press 'K' on an entry like 'vector::insert(3)' links you to the manual page of vector::insert, like a hyperlink.
 .SS man compatibility
-cppman automatically adds '~/.local/share/man' to '~/.manpath', so the cached man pages can also be viewed with 'man' command. Note that to view uncached man pages, you still need to run 'cppman'.
+cppman automatically adds '$XDG_CACHE_HOME/cppman/man' to '~/.manpath', so the cached man pages can also be viewed with 'man' command. Note that to view uncached man pages, you still need to run 'cppman'.
 .SH OPTIONS
 .IP "\-s SOURCE, \-\-source=SOURCE"
 Select source, either 'cppreference.com' or 'cplusplus.com'. Default is 'cplusplus.com'.


### PR DESCRIPTION
This PR is supposed to fix #45 and both issues in #74 


== Moving Paths
Instead of using ~/.config/cppman and ~/.local/share/man now XDG_* env
variables are being used:
$XDG_CONFIG_HOME/cppman (= ~/.config/cppman)
$XDG_CACHE_HOME/cppman  (= ~/.cache/cppman)

Following things have moved:
~/.config/cppman/cppman.cfg → $XDG_CONFIG_HOME/cppman/cppman.cfg
~/.config/cppman/index.db   → $XDG_CACHE_HOME/cppman/index.db
~/.local/share/man/*        → $XDG_CACHE_HOME/cppman/

== Fix and Extend .manpath
This also adds another entry to "~/.mandb" to allow indexing of man pages
and searching. (need to call mandb to successfully index entries)

Also `cppman -k false` now removes the entries from .manpath