### PR TITLE
VIM PAGER: set buftype=nofile

### DIFF
--- a/cppman/lib/cppman.vim
+++ b/cppman/lib/cppman.vim
@@ -38,6 +38,7 @@ setl nornu
 setl noma
 setl iskeyword+=:,=,~,[,],*,!,<,>
 setl keywordprg=cppman
+setl buftype=nofile
 noremap <buffer> q :q!<CR>
 
 if version < 600


### PR DESCRIPTION
This makes vim consider the buffer a scratch buffer so you can exit
normally with `:q` even if the buffer changed.

It removes the `[noperm]` indicator as well. I figured vim users are used to exiting with `:q` and it gets annoying to be asked to save changes.