### PR TITLE
Different exit code if man page could not be found.

### DIFF
--- a/bin/cppman
+++ b/bin/cppman
@@ -157,6 +157,7 @@ def main():
 
     cm = Cppman(options.force, options.force_columns)
     first = True
+    failure = False
     for i in args:
         if not first:
             print('--CppMan-- next: %s(3) [ view (return) | skip (Ctrl-D) '
@@ -183,9 +184,12 @@ def main():
             pid = cm.man(i)
         except RuntimeError as e:
             print(e)
+            failure = True
             continue
         else:
             os.waitpid(pid, 0)
+    if failure:
+      sys.exit(1)
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
If one of the search terms can't be found this will return an exit code 1.

Should solve issue #93 