### PR TITLE
Fix: search cppman with regex symbols

### DIFF
--- a/cppman/main.py
+++ b/cppman/main.py
@@ -294,7 +294,7 @@ class Cppman(Crawler):
             'LIKE "%%%s%%" ORDER BY LENGTH(name)'
             % (environ.source, pattern)).fetchall()
 
-        pat = re.compile('(%s)' % pattern, re.I)
+        pat = re.compile('(%s)' % re.escape(pattern), re.I)
 
         if selected:
             for name, url, std in selected:


### PR DESCRIPTION
Fixes issue #97 .
cppman -f "C++" didn't work. This adds escape sequences to the search
pattern.