### PR TITLE
Patch: Change call to vim pager to avoid "reading from stdin"

### DIFF
--- a/cppman/lib/cppman.vim
+++ b/cppman/lib/cppman.vim
@@ -89,7 +89,6 @@ setl mouse=a
 setl colorcolumn=0
 
 let s:old_col = &co
-echo s:old_col
 
 function s:reload()
   setl noro

--- a/cppman/lib/pager.sh
+++ b/cppman/lib/pager.sh
@@ -71,8 +71,10 @@ case $pager_type in
     render | $PAGER
     ;;
   vim)
-    render | remove_escape | \
-      vim -R -c "let g:page_name=\"$page_name\"" -S $vim_config -
+
+    render | remove_escape 3<&- | {
+      vim -R -c "let g:page_name=\"$page_name\"" -S $vim_config /dev/fd/3 </dev/tty
+    } 3<&0
     ;;
   less)
     render | less


### PR DESCRIPTION
Fixes issue #92 .

calling `cppman vector" would always leave a "Vim: Reading from
stdin..." message on the command line. This is not pretty.
This commit rewrites how vim is being called fixing this issue.