### PR TITLE
Feat: add bash and zsh completion files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,8 @@ FAQ
 ---
 * Q: Can I use the system ``man`` command instead of ``cppman``?
 * A: Yes, just execute ``cppman -m true`` and all cached man pages are exposed to the system ``man`` command.  Note: You may want to download all available man pages with ``cppman -c``.
+* Q: Why is bash completion is not working properly with "::"?
+* A: It is because bash treats ':' like a white space. To fix this add `export COMP_WORDBREAKS=" /\"\'><;|&("` to your `~/.bashrc`.
 
 Bugs
 ----

--- a/misc/completions/cppman.bash
+++ b/misc/completions/cppman.bash
@@ -1,0 +1,22 @@
+_cppman ()
+{
+	if [ "${#COMP_WORDS[@]}" -gt 2 ]; then
+		return
+	fi
+	if [ -z "${COMP_WORDS[1]}" ]; then
+		return
+	fi
+	P=${COMP_LINE[0]}
+	W=${COMP_WORDS[1]}
+
+	PERLP=$(printf 'if (m/^(.*?%q[^:]*)(::)?.*$/) { print "$1$2$/"; }' $W)
+
+	params="$($P -f "$W" | perl -ne "$PERLP" \
+		| perl -ne '/^([^\[]*)(\W\[.*\].*)?$/; print "$1\n"' \
+		| perl -ne '/^((?:std::)?)(.*)$/; print "$2\n$1$2\n"' \
+		| sort -u | xargs -d '\n' printf '%q ')"
+
+	COMPREPLY=($(compgen -W "$params" "$W"))
+
+}
+complete -F _cppman cppman

--- a/misc/completions/cppman.zsh
+++ b/misc/completions/cppman.zsh
@@ -1,0 +1,18 @@
+_cppman ()
+{
+	P=cppman
+	if [ ${#words[@]} -gt 2 ]; then
+		return
+	fi
+	W=$(eval echo ${words[@]:1})
+	PERLP=$(printf 'if (m/^(.*?%q[^:]*)(::)?.*$/) { print "$1$2$/"; }' $W)
+
+	params="$($P -f "$W" | perl -ne "$PERLP" \
+		| perl -ne '/^([^\[]*)(\W\[.*\].*)?$/; print "$1\n"' \
+		| perl -ne '/^((?:std::)?)(.*)$/; print "$2\n$1$2\n"' \
+		| sort -u | xargs -d '\n' printf '%q ')"
+
+
+	eval "compadd -X "%USuggestions%u" -- $params"
+}
+compdef _cppman -P cppman -N

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,9 @@ _package_data = [
 
 _data_files = [
         ('share/doc/cppman', ['README.rst', 'AUTHORS', 'COPYING', 'ChangeLog']),
-        ('share/man/man1', ['misc/cppman.1'])
+        ('share/man/man1', ['misc/cppman.1']),
+        ('share/bash-completion/completions', ['misc/completions/cppman.bash']),
+        ('share/zsh-completion/completions', ['misc/completions/cppman.zsh'])
         ]
 
 setup(


### PR DESCRIPTION
Feat: add bash and zsh completion files

This adds completions file for bash and zsh.
The setup.py is changed so the files are being installed to
- <root>/share/bash-completion/completions/cppman.bash
- <root>/share/zsh-completion/completions/cppman.zsh

Bash treats ':' as white spaces which makes using bash completion not as
nice as I wished (zsh does not have this issue). This can be fixed for
bash by adding the following line to `~/.bashrc`

```
export COMP_WORDBREAKS=" /\"\'><;|&("
```

![cppman-srceen](https://user-images.githubusercontent.com/456045/55730758-3a482680-5a19-11e9-9b61-6ed55b60c74d.png)
