### PR TITLE
Add python 3.8 and deprecate 3.3 and 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
+dist: bionic
 language: python
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
+
 script:
   - pip install --upgrade pip setuptools
   - pip install .

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,10 @@ setup(
         scripts = ['bin/cppman'],
         install_requires=['beautifulsoup4', 'html5lib'],
         classifiers = [
-            'Programming Language :: Python :: 3.3',
-            'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3 :: Only',
             'Topic :: Software Development :: Documentation',
         ],


### PR DESCRIPTION
relates to https://github.com/Homebrew/homebrew-core/pull/49077 (the formula already shipped with python 3.8)