### PR TITLE
change bash completion script

### DIFF
--- a/misc/completions/cppman.bash
+++ b/misc/completions/cppman.bash
@@ -1,6 +1,6 @@
 cppman()
 {
-    command cppman ${1//\//::}
+    command cppman "${*//\//::}"
 }
 _cppman()
 { 


### PR DESCRIPTION
This script solve  `$COMP_WORDBREAKS` variable problem that bash has.
and use `/` character instead `::` for completion.