### PR TITLE
A more rubust crawler

### DIFF
--- a/cppman/crawler.py
+++ b/cppman/crawler.py
@@ -93,7 +93,6 @@ class Crawler(object):
         return links
 
     def crawl(self, url, path=None):
-        self.results = {}
         self.url = urlparse(url)
         if path:
             self.url = self.url._replace(path=path)
@@ -143,8 +142,6 @@ class Crawler(object):
             for depth, url in self.failed_targets:
                 print("{} (depth {})".format(url, depth))
         print("=== Done {}".format(url))
-
-        return self.results
 
     def process_document(self, url, content, depth):
         """callback to insert index"""

--- a/cppman/main.py
+++ b/cppman/main.py
@@ -265,7 +265,7 @@ class Cppman(Crawler):
 
     def _extract_name(self, data):
         """Extract man page name from web page."""
-        name = re.search('<h1[^>]*>(.+?)</h1>', data).group(1)
+        name = re.search('<[hH]1[^>]*>(.+?)</[hH]1>', data, re.DOTALL).group(1)
         name = re.sub(r'<([^>]+)>', r'', name)
         name = re.sub(r'&gt;', r'>', name)
         name = re.sub(r'&lt;', r'<', name)

--- a/cppman/main.py
+++ b/cppman/main.py
@@ -398,7 +398,8 @@ class Cppman(Crawler):
                         typedefTable = True
                     elif typedefTable:
                         res = re.search('^\s*(\S*)\s+.*$', tds[0].get_text())
-                        names.append(res.group(1))
+                        if res and res.group(1):
+                            names.append(res.group(1))
                     elif not typedefTable:
                         break
             if typedefTable:


### PR DESCRIPTION
This PR fixes and enhances the crawler which currently looses quite a lot URLs due to network errors. For example, the number of pages in the cppreference.com table increases from 4286 to 5341. Now all failed downloads are collected and retried after a round of crawling. The process continues until either 1) there are no failed downloads or 2) no download progress is seen for a number of rounds (`self.max_failed_retries`).

The PR also fixes the issue with multiple pages having the same title such as [std::move](https://en.cppreference.com/w/cpp/algorithm/move) and [std::move](https://en.cppreference.com/w/cpp/utility/move). In such cases a part of the path is added to the title resulting in `std::move (algorithm)` and `std::move (utility)`. There are 126 such pages (both cplusplus.com and cppreference.com).