### PR TITLE
Add custom headers to requests

### DIFF
--- a/cppman/crawler.py
+++ b/cppman/crawler.py
@@ -32,6 +32,7 @@ from urllib.parse import urljoin, urlparse, urlunparse
 import urllib.request
 import urllib.error
 import http.client
+import cppman.util
 
 from bs4 import BeautifulSoup
 
@@ -205,7 +206,7 @@ class Crawler(object):
                 depth, url = sorted(self.targets)[0]
                 self.targets.remove((depth, url))
 
-            opener = urllib.request.build_opener(NoRedirection)
+            opener = cppman.util.build_opener(NoRedirection)
             request_error = None
             try:
                 res = opener.open(url, timeout=10)

--- a/cppman/formatter/cplusplus.py
+++ b/cppman/formatter/cplusplus.py
@@ -24,10 +24,9 @@
 
 import datetime
 import re
-import urllib.request
 
 from cppman.formatter.tableparser import parse_table
-from cppman.util import fixupHTML, html2man
+from cppman.util import fixupHTML, html2man, urlopen
 
 # Format replacement RE list
 # The '.SE' pseudo macro is described in the function: html2groff
@@ -223,7 +222,7 @@ def html2groff(data, name):
 
 def func_test():
     """Test if there is major format changes in cplusplus.com"""
-    ifs = urllib.request.urlopen('http://www.cplusplus.com/printf')
+    ifs = urlopen('http://www.cplusplus.com/printf')
     result = html2groff(fixupHTML(ifs.read()), 'printf')
     assert '.SH "NAME"' in result
     assert '.SH "TYPE"' in result
@@ -232,7 +231,7 @@ def func_test():
 
 def test():
     """Simple Text"""
-    ifs = urllib.request.urlopen('http://www.cplusplus.com/vector')
+    ifs = urlopen('http://www.cplusplus.com/vector')
     print(html2groff(fixupHTML(ifs.read()), 'std::vector'), end=' ')
     # with open('test.html') as ifs:
     #    print html2groff(fixupHTML(ifs.read()), 'std::vector'),

--- a/cppman/formatter/cppreference.py
+++ b/cppman/formatter/cppreference.py
@@ -25,11 +25,10 @@
 import datetime
 import re
 import string
-import urllib.request
 from functools import partial
 
 from cppman.formatter.tableparser import parse_table
-from cppman.util import fixupHTML, html2man
+from cppman.util import fixupHTML, html2man, urlopen
 
 
 def member_table_def(g):
@@ -315,8 +314,7 @@ def html2groff(data, name):
 
 def func_test():
     """Test if there is major format changes in cplusplus.com"""
-    ifs = urllib.request.urlopen(
-        'http://en.cppreference.com/w/cpp/container/vector')
+    ifs = urlopen('http://en.cppreference.com/w/cpp/container/vector')
     result = html2groff(fixupHTML(ifs.read()), 'std::vector')
     assert '.SH "NAME"' in result
     assert '.SH "SYNOPSIS"' in result
@@ -325,8 +323,7 @@ def func_test():
 
 def test():
     """Simple Text"""
-    ifs = urllib.request.urlopen(
-        'http://en.cppreference.com/w/cpp/container/vector')
+    ifs = urlopen('http://en.cppreference.com/w/cpp/container/vector')
     print(html2groff(fixupHTML(ifs.read()), 'std::vector'), end=' ')
     # with open('test.html') as ifs:
     #    data = fixupHTML(ifs.read())

--- a/cppman/main.py
+++ b/cppman/main.py
@@ -33,7 +33,6 @@ import shutil
 import sqlite3
 import subprocess
 import sys
-import urllib.request
 
 from bs4 import BeautifulSoup
 from cppman import environ, util
@@ -499,7 +498,7 @@ class Cppman(Crawler):
 
         # There are often some errors in the HTML, for example: missing closing
         # tag. We use fixupHTML to fix this.
-        data = util.fixupHTML(urllib.request.urlopen(url).read())
+        data = util.fixupHTML(util.urlopen(url).read())
 
         formatter = importlib.import_module(
             'cppman.formatter.%s' % source[:-4])

--- a/cppman/util.py
+++ b/cppman/util.py
@@ -24,14 +24,14 @@
 
 import os
 import shutil
-import struct
 import subprocess
-import sys
-import termios
+import urllib.request
 
 import bs4
 from cppman import environ
 
+# User-Agent header value to use with all requests
+_USER_AGENT = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/111.0"
 
 def update_mandb_path():
     """Add $XDG_CACHE_HOME/cppman/man to $HOME/.manpath"""
@@ -108,3 +108,18 @@ def html2man(data, formatter):
 
 def fixupHTML(data):
     return str(bs4.BeautifulSoup(data, "html5lib"))
+
+def urlopen(url, *args, **kwargs):
+    """A wrapper around urllib.request.urlopen() which adds custom headers"""
+    if isinstance(url, urllib.request.Request):
+        req = url
+    else:
+        req = urllib.request.Request(url)
+    req.add_header('User-Agent', _USER_AGENT)
+    return urllib.request.urlopen(req, *args, **kwargs)
+
+def build_opener(*args, **kwargs):
+    """A wrapper around urllib.request.build_opener() which adds custom headers"""
+    opener = urllib.request.build_opener(*args, **kwargs)
+    opener.addheaders = [('User-Agent', _USER_AGENT)]
+    return opener


### PR DESCRIPTION
Looks like cppreference is blocking urllib requests now. This PR fixes it. To test run

    PYTHONPATH=. python3 cppman/formatter/cppreference.py

After adding custom headers indexing works much faster. Maybe we should consider slowing it down to put less stress on the sites.