### PR TITLE
Add `-r` option to pager `less` command to follow control chars

### DIFF
--- a/cppman/lib/pager.sh
+++ b/cppman/lib/pager.sh
@@ -91,7 +91,7 @@ case $pager_type in
     } 3<&0
     ;;
   less)
-    render | less
+    render | less -r
     ;;
   pipe)
     render | remove_escape


### PR DESCRIPTION
Now pager `less` shows format-styling escape sequence `^Esc` as it is.
Needs `-r` option.