### PR TITLE
Change exit code if no entry found

### DIFF
--- a/bin/cppman
+++ b/bin/cppman
@@ -161,7 +161,7 @@ def main():
     try:
         pid = cm.man(args[0])
     except RuntimeError as e:
-        print(e)
+        print(e, file=sys.stderr)
         sys.exit(16)
     else:
         os.waitpid(pid, 0)
@@ -173,6 +173,6 @@ if __name__ == '__main__':
         sys.exit()
     except (Exception, KeyboardInterrupt) as e:
         if type(e) == KeyboardInterrupt:
-            print('\nAborted.')
+            print('\nAborted.', file=sys.stderr)
         else:
-            print('error:', e)
+            print('error:', e, file=sys.stderr)

--- a/bin/cppman
+++ b/bin/cppman
@@ -162,6 +162,7 @@ def main():
         pid = cm.man(args[0])
     except RuntimeError as e:
         print(e)
+        sys.exit(16)
     else:
         os.waitpid(pid, 0)
 


### PR DESCRIPTION
As `man` command, return exit code `16` for not-found case.