### PR TITLE
Properly escape regex string literals

### DIFF
--- a/cppman/formatter/cppreference.py
+++ b/cppman/formatter/cppreference.py
@@ -50,7 +50,7 @@ def member_type_function(g):
         tail = ' ' + spectag.group(2)
 
     cppvertag = re.search(
-        '^(.*?)(\[(?:(?:since|until) )?C\+\+\d+\]\s*(,\s*)?)+$', head)
+        r'^(.*?)(\[(?:(?:since|until) )?C\+\+\d+\]\s*(,\s*)?)+$', head)
     if cppvertag:
         head = cppvertag.group(1).strip()
         tail = ' ' + cppvertag.group(2)
@@ -117,7 +117,7 @@ rps = [
     # Group t-lines
     (r'<span></span>', r'', re.S),
     (r'<span class="t-lines">(?:<span>.+?</span>.*)+</span>',
-     lambda x: re.sub('\s*</span><span>\s*', r', ', x.group(0)), re.S),
+     lambda x: re.sub(r'\s*</span><span>\s*', r', ', x.group(0)), re.S),
     # Member type & function second col is group see basic_fstream for example
     (r'<tr class="t-dsc">\s*?<td>((?:(?!</td>).)*?)</td>\s*?'
      r'<td>((?:(?!</td>).)*?)<table[^>]*>((?:(?!</table>).)*?)</table>'

--- a/cppman/formatter/tableparser.py
+++ b/cppman/formatter/tableparser.py
@@ -144,7 +144,7 @@ class Node(object):
             ci = 0
             for i in range(total):
                 if i in rowspan:
-                    fd.write('\^%s' % ('|' if i < total - 1 else ''))
+                    fd.write(r'\^%s' % ('|' if i < total - 1 else ''))
                     if rowspan[i] == 1:
                         del rowspan[i]
                     else:

--- a/cppman/main.py
+++ b/cppman/main.py
@@ -129,7 +129,7 @@ class Cppman(Crawler):
         self.db_conn = sqlite3.connect(environ.index_db_re)
         self.db_cursor = self.db_conn.cursor()
         try:
-            self.add_url_filter('\.(jpg|jpeg|gif|png|js|css|swf|svg)$')
+            self.add_url_filter(r'\.(jpg|jpeg|gif|png|js|css|swf|svg)$')
             self.set_follow_mode(Crawler.F_SAME_PATH)
 
             sources = [('cplusplus.com', 'https://cplusplus.com/reference/', None),
@@ -399,10 +399,10 @@ class Cppman(Crawler):
             for tr in x.find_all('tr'):
                 tds = tr.find_all('td')
                 if len(tds) == 2:
-                    if re.match("\s*Type\s*", tds[0].get_text()):
+                    if re.match(r"\s*Type\s*", tds[0].get_text()):
                         typedefTable = True
                     elif typedefTable:
-                        res = re.search('^\s*(\S*)\s+.*$', tds[0].get_text())
+                        res = re.search(r'^\s*(\S*)\s+.*$', tds[0].get_text())
                         if res and res.group(1):
                             names.append(res.group(1))
                     elif not typedefTable:
@@ -420,7 +420,7 @@ class Cppman(Crawler):
                 if e.name == "table":
                     for tr in e.find_all('tr'):
                         text = re.sub('\n', ' ', tr.get_text())
-                        res = re.search('^.* (\S+)\s*=.*$', text)
+                        res = re.search(r'^.* (\S+)\s*=.*$', text)
                         if res:
                             names.append(res.group(1))
         # search for "Helper types" list
@@ -433,7 +433,7 @@ class Cppman(Crawler):
                 if e.name == "table":
                     for tr in e.find_all('tr'):
                         text = re.sub('\n', ' ', tr.get_text())
-                        res = re.search('^.* (\S+)\s*=.*$', text)
+                        res = re.search(r'^.* (\S+)\s*=.*$', text)
                         if res:
                             names.append(res.group(1))
         return [html.unescape(n) for n in names]
@@ -583,7 +583,7 @@ class Cppman(Crawler):
 
         results = self._search_keyword(pattern)
 
-        pat = re.compile('(.*?)(%s)(.*?)( \(.*\))?$' %
+        pat = re.compile(r'(.*?)(%s)(.*?)( \(.*\))?$' %
                          re.escape(pattern), re.I)
 
         if results:


### PR DESCRIPTION
Python3.11 and newer versions like to complain about unknown escape sequences like `\.`, `\s` etc.

When you install cppman through a package manager on Linux, you'll see something similar to this:
```
...
cppman-0.5.6_2: configuring ...
Byte-compiling python3.12 code for module cppman...
usr/lib/python3.12/site-packages/cppman/formatter/cppreference.py:47: SyntaxWarning: invalid escape sequence '\['
  '^(.*?)(\[(?:(?:since|until) )?C\+\+\d+\]\s*(,\s*)?)+$', head)
usr/lib/python3.12/site-packages/cppman/formatter/cppreference.py:115: SyntaxWarning: invalid escape sequence '\s'
  lambda x: re.sub('\s*</span><span>\s*', r', ', x.group(0)), re.S),
usr/lib/python3.12/site-packages/cppman/formatter/tableparser.py:147: SyntaxWarning: invalid escape sequence '\^'
  fd.write('\^%s' % ('|' if i < total - 1 else ''))
usr/lib/python3.12/site-packages/cppman/main.py:126: SyntaxWarning: invalid escape sequence '\.'
  self.add_url_filter('\.(jpg|jpeg|gif|png|js|css|swf|svg)$')
usr/lib/python3.12/site-packages/cppman/main.py:396: SyntaxWarning: invalid escape sequence '\s'
  if re.match("\s*Type\s*", tds[0].get_text()):
usr/lib/python3.12/site-packages/cppman/main.py:399: SyntaxWarning: invalid escape sequence '\s'
  res = re.search('^\s*(\S*)\s+.*$', tds[0].get_text())
usr/lib/python3.12/site-packages/cppman/main.py:417: SyntaxWarning: invalid escape sequence '\S'
  res = re.search('^.* (\S+)\s*=.*$', text)
usr/lib/python3.12/site-packages/cppman/main.py:430: SyntaxWarning: invalid escape sequence '\S'
  res = re.search('^.* (\S+)\s*=.*$', text)
usr/lib/python3.12/site-packages/cppman/main.py:580: SyntaxWarning: invalid escape sequence '\('
  pat = re.compile('(.*?)(%s)(.*?)( \(.*\))?$' %
usr/lib/python3.12/site-packages/cppman/formatter/cppreference.py:47: SyntaxWarning: invalid escape sequence '\['
  '^(.*?)(\[(?:(?:since|until) )?C\+\+\d+\]\s*(,\s*)?)+$', head)
usr/lib/python3.12/site-packages/cppman/formatter/cppreference.py:115: SyntaxWarning: invalid escape sequence '\s'
  lambda x: re.sub('\s*</span><span>\s*', r', ', x.group(0)), re.S),
usr/lib/python3.12/site-packages/cppman/formatter/tableparser.py:147: SyntaxWarning: invalid escape sequence '\^'
  fd.write('\^%s' % ('|' if i < total - 1 else ''))
usr/lib/python3.12/site-packages/cppman/main.py:126: SyntaxWarning: invalid escape sequence '\.'
  self.add_url_filter('\.(jpg|jpeg|gif|png|js|css|swf|svg)$')
usr/lib/python3.12/site-packages/cppman/main.py:396: SyntaxWarning: invalid escape sequence '\s'
  if re.match("\s*Type\s*", tds[0].get_text()):
usr/lib/python3.12/site-packages/cppman/main.py:399: SyntaxWarning: invalid escape sequence '\s'
  res = re.search('^\s*(\S*)\s+.*$', tds[0].get_text())
usr/lib/python3.12/site-packages/cppman/main.py:417: SyntaxWarning: invalid escape sequence '\S'
  res = re.search('^.* (\S+)\s*=.*$', text)
usr/lib/python3.12/site-packages/cppman/main.py:430: SyntaxWarning: invalid escape sequence '\S'
  res = re.search('^.* (\S+)\s*=.*$', text)
usr/lib/python3.12/site-packages/cppman/main.py:580: SyntaxWarning: invalid escape sequence '\('
  pat = re.compile('(.*?)(%s)(.*?)( \(.*\))?$' %
...
```

This PR fixes these warnings.