### PR TITLE
global vim variable 'is_cppman_active'

### DIFF
--- a/cppman/lib/pager.sh
+++ b/cppman/lib/pager.sh
@@ -84,15 +84,22 @@ case $pager_type in
     [ -z "$PAGER" ] && PAGER=less
     render | $PAGER
     ;;
-  vim|nvim)
 
+  vim|nvim)
     render | remove_escape 3<&- | {
-      $pager_type -R -c "let g:page_name=\"$page_name\"" -S $vim_config /dev/fd/3 </dev/tty
+      $pager_type \
+        --cmd "let g:is_cppman_active=1" \
+        -R \
+        -c "let g:page_name=\"$page_name\"" \
+        -S $vim_config \
+        /dev/fd/3 </dev/tty
     } 3<&0
     ;;
+
   less)
     render | less -r
     ;;
+
   pipe)
     render | remove_escape
 esac


### PR DESCRIPTION
This PR adds the command line argument `--cmd "let g:is_cppman_active=1"` in `pager.sh` when using `vim` or `nvim` as a pager.

This is useful, because commands provided with `--cmd` are processed before any vimrc file is processed (see manpage for vim/nvim), which means the user can check in their `init.lua` or `init.vim` file if the current vim instance has been launched by `cppman` (by checking the value of `is_cppman_active`) and can therefore choose to omit certain configurations or abstain from loading some plugins.