### PR TITLE
Fix alias insertion

### DIFF
--- a/cppman/main.py
+++ b/cppman/main.py
@@ -198,7 +198,7 @@ class Cppman(Crawler):
                             % (table, k, k, k, k, k, k)).fetchall()
 
                         for id, keyword in sql_results:
-                            keyword = keyword.replace("%s" % k, "%s" % a)
+                            keyword = re.sub(re.escape("%s" % k), "%s" % a, keyword, flags=re.IGNORECASE)
 
                             self.db_cursor.execute(
                                 'INSERT INTO "%s_keywords" (id, keyword) '


### PR DESCRIPTION
SQLite LIKE operator is case-insensitive. Hence the replacement must be case-insensitive too. If it is not, the keyword found by LIKE might not be replaced and will be found again and again. That will cause unlimited growth of sql_results.

Example:
https://en.cppreference.com/w/cpp/memory/allocator and Allocator  template argument

Another option would be using GLOB instead of LIKE for case-sensitive search. Whether it is better or not and search pattern selection is out of scope of this commit.