### PR TITLE
Return error exit code if no entry found for the keyword

### DIFF
--- a/bin/cppman
+++ b/bin/cppman
@@ -115,8 +115,12 @@ def main():
         sys.exit(0)
 
     if options.keyword:
-        cm.find(options.keyword)
-        sys.exit(0)
+        try:
+            cm.find(options.keyword)
+            sys.exit(0)
+        except RuntimeError as e:
+            print(e, file=sys.stderr)
+            sys.exit(16)
 
     if options.source:
         if options.source not in config.SOURCES:
@@ -154,11 +158,11 @@ def main():
         sys.stderr.write('What manual page do you want?\n')
         sys.exit(1)
 
-    keyword = cm.fuzzy_find(args[0])
-    if not keyword:
-        sys.exit(1)
-
     try:
+        keyword = cm.fuzzy_find(args[0])
+        if not keyword:
+            sys.exit(1)
+
         pid = cm.man(keyword)
     except RuntimeError as e:
         print(e, file=sys.stderr)


### PR DESCRIPTION
The same fix of #169, for keyword search.

Not-found cases should be informed by exit code, to check the command result.
